### PR TITLE
Now accepts target data/image directories, as well as multiple source directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,19 @@ asset files should share an initial root and then end in incrementing numbers, e
    
 Running spriter on a directory with those files will generate a sprite sheet with 2 sprites, mario and luigi,
 and 3 mario frames and 2 luigi frames.
+
+Advanced Usage
+--------------
+
+You may specify multiple source directories, as well as target directories for `sprites.png` and `sprites.json`.
+
+    spriter <source_dir>... [-d <data_target_dir>] [-i <images_target_dir>]
+
+Examples:
+
+    spriter project/assets_dir1 project/more_assets ../some_other_dir
+    spriter -i project/images project/assets -d project/data
+    spriter -d project/data project/assets_1 project/assets_2
+    spriter src/images -i dist/images -d dist/data
+
+Arguments may be specified in any order. The target directories also don't need to exist yet. Parent directories will be created recursively as needed.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Advanced Usage
 You may specify multiple source directories, as well as target directories for `sprites.png` and `sprites.json`.
 
     spriter <source_dir>... [-d <data_target_dir>] [-i <images_target_dir>]
+    
+Options:
+
+* `-d`:  Precedes name of directory where `sprites.json` will be placed.
+
+* `-i`:  Precedes name of directory where `sprites.png` will be placed.
 
 Examples:
 

--- a/bin/spriter
+++ b/bin/spriter
@@ -1,5 +1,26 @@
 #!/usr/bin/env node
 
-var spriter = require('../spriter');
+var spriter = require('../spriter'),
+    minimist = require('minimist');
 
-spriter(process.argv[2]);
+var parsedArgs = minimist(process.argv.slice(2));
+
+if(!parsedArgs._.length) {
+  console.error('No source directory supplied; exiting.');
+  process.exit(1);
+}
+
+function filterArg(arg) {
+  return typeof arg === 'string' ? arg : undefined;
+}
+
+var options = {
+  sourceDirectories: parsedArgs._,
+  imageDestination: filterArg(parsedArgs.i),
+  dataDestination: filterArg(parsedArgs.d)
+};
+
+console.log(typeof(options.imageDestination));
+console.log(typeof(options.dataDestination));
+
+spriter(options);

--- a/bin/spriter
+++ b/bin/spriter
@@ -20,7 +20,4 @@ var options = {
   dataDestination: filterArg(parsedArgs.d)
 };
 
-console.log(typeof(options.imageDestination));
-console.log(typeof(options.dataDestination));
-
 spriter(options);

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "author": "Pascal Rettig",
   "version": "0.0.3",
   "dependencies": {
-    "canvas" : "1.2.1",
-    "futures": "2.3.3"
+    "canvas": "1.2.1",
+    "futures": "2.3.3",
+    "minimist": "^1.2.0",
+    "mkdirp": "^0.5.1"
   },
   "bin": "./bin/spriter",
   "main": "./spriter.js"
 }
-


### PR DESCRIPTION
I extended Spriter to accept optional arguments for target directories where `sprites.png` and `sprites.json` can be written, rather than the working directory. Also, you can now accept multiple source directories should you choose.

Why did I want this? So I can easily incorporate Spriter into an automated build process, that takes assets from my `src/images` directory and writes the resulting files to `dist/images/sprites.png` and `dist/data/sprites.json`.

A detailed explanation can be found in the bit I added to README.md (reproduced below):
## Advanced Usage

You may specify multiple source directories, as well as target directories for `sprites.png` and `sprites.json`.

```
spriter <source_dir>... [-d <data_target_dir>] [-i <images_target_dir>]
```

Options:
- `-d`:  Precedes name of directory where `sprites.json` will be placed.
- `-i`:  Precedes name of directory where `sprites.png` will be placed.

Examples:

```
spriter project/assets_dir1 project/more_assets ../some_other_dir
spriter -i project/images project/assets -d project/data
spriter -d project/data project/assets_1 project/assets_2
spriter src/images -i dist/images -d dist/data
```

Arguments may be specified in any order. The target directories also don't need to exist yet. Parent directories will be created recursively as needed.
